### PR TITLE
typo: replaced 'in' with 'is' ESK processing

### DIFF
--- a/attila/atre.py
+++ b/attila/atre.py
@@ -368,7 +368,7 @@ class ATRuntimeEnvironment(object):
       #Replace session values
       to_out = self.__session.replace_session_keys(esk.value)
       print(to_out)
-    elif esk.keyword in ESK.EXEC:
+    elif esk.keyword is ESK.EXEC:
       rc = system(esk.value)
       if rc != 0:
         return False


### PR DESCRIPTION
Signed-off-by: Paul Butler <butler.paul@gmail.com>

# Pull Request

## Description

Trying to use EXEC ESK feature I kept getting an exception. Debugging found a typo.

Fixes # (issue)

## Type of change

Please select relevant options.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the contribution guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My changes generate no new memory leaks
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
